### PR TITLE
Fix a small issue when updating the memory

### DIFF
--- a/Evaluate.py
+++ b/Evaluate.py
@@ -139,7 +139,7 @@ for k,(imgs) in enumerate(test_batch):
     if  point_sc < args.th:
         query = F.normalize(feas, dim=1)
         query = query.permute(0,2,3,1) # b X h X w X d
-        m_items_test = model.memory.update(query, m_items_test, False)
+        m_items_test = model.memory.update(query, m_items_test)
 
     psnr_list[videos_list[video_num].split('/')[-1]].append(psnr(mse_imgs))
     feature_distance_list[videos_list[video_num].split('/')[-1]].append(mse_feas)

--- a/Train.py
+++ b/Train.py
@@ -128,7 +128,7 @@ for epoch in range(args.epochs):
         loss = loss_pixel + args.loss_compact * compactness_loss + args.loss_separate * separateness_loss
         loss.backward(retain_graph=True)
         optimizer.step()
-        
+
     scheduler.step()
     
     print('----------------------------------------')

--- a/Train.py
+++ b/Train.py
@@ -128,6 +128,8 @@ for epoch in range(args.epochs):
         loss = loss_pixel + args.loss_compact * compactness_loss + args.loss_separate * separateness_loss
         loss.backward(retain_graph=True)
         optimizer.step()
+
+        print(j)
         
     scheduler.step()
     


### PR DESCRIPTION
@hyunjp Hi,

Thanks for your nice work! As I dived into the source code, I just noticed a small issue when we updating the memory as the operations you provided in your paper. To be more concrete, that's formula (5) in the `Update` part of section 3.1.1. And the corresponding code you wrote is [>>here<<](https://github.com/cvlab-yonsei/MNAD/blob/master/model/memory_final_spatial_sumonly_weight_ranking_top1.py#L97).

I noticed that the `score[:,i]` just represents the similarities between i-th memory item and all the queries. But what we really want to get is the part of queries, whose closet memory item are exact the i-th memory item. So, `score[:,i]` should be modified into `score[idx,i]`. You can refer to 
$\max _{k^{\prime} \in U_{t}^{m}} v_{t}^{k^{\prime}, n}$ in formula (5).
And I clean up the code about the memory updating part. To be short, here are what I've done:
- fix the small bug as I pointed out above;
- clean up the code, specifically, I discard the unused param `update_indices ` and unneeded param `train` in function `get_update_query()` and clean the implementation;
- modify the `Evaluate.py` correspondingly.

If I was wrong, please correct me. Thanks in advance. 😸 

